### PR TITLE
Test KVS allows numerical values

### DIFF
--- a/docido_sdk/index/test.py
+++ b/docido_sdk/index/test.py
@@ -23,6 +23,7 @@ from docido_sdk.toolbox.http_ext import delayed_request
 
 
 reraise = reraise(IndexAPIError)
+ALLOWED_CHECKPOINT_VALUE_TYPES = six.string_types + (int, long, float)
 
 
 class CustomJSONEncoder(json.JSONEncoder):
@@ -71,7 +72,7 @@ class LocalKVProcessor(IndexAPIProcessor):
     @reraise
     def set_kv(self, key, value):
         assert isinstance(key, six.string_types)
-        assert isinstance(value, six.string_types)
+        assert isinstance(value, ALLOWED_CHECKPOINT_VALUE_TYPES)
         with self.__lock.write():
             self.__store[key] = value
             self.__persist()

--- a/tests/test_local_kv.py
+++ b/tests/test_local_kv.py
@@ -87,6 +87,21 @@ class TestLocalKV(unittest.TestCase):
             kv.delete_kvs()
             self.assertEqual({}, kv.get_kvs())
 
+    def test_valid_value(self):
+        with self.kv() as kv:
+            kv.set_kv('k1', 'a_string')
+            kv.set_kv('k2', 42)
+            kv.set_kv('k3', long(42))
+            kv.set_kv('k4', 3.14)
+            self.assertEqual(kv.get_kv('k1'), 'a_string')
+            self.assertEqual(type(kv.get_kv('k1')), str)
+            self.assertEqual(kv.get_kv('k2'), 42)
+            self.assertEqual(type(kv.get_kv('k2')), int)
+            self.assertEqual(kv.get_kv('k3'), 42)
+            self.assertEqual(type(kv.get_kv('k3')), long)
+            self.assertEqual(kv.get_kv('k4'), 3.14)
+            self.assertEqual(type(kv.get_kv('k4')), float)
+
     def test_key_is_None(self):
         with self.kv() as kv:
             with self.assertRaises(IndexAPIError):


### PR DESCRIPTION
Key value storage classes used to validate developments now allows numerical values.

fixes #9
