### PR TITLE
Bump Elasticsearch to 2.3

### DIFF
--- a/docido_sdk/index/processor/es_api.py
+++ b/docido_sdk/index/processor/es_api.py
@@ -108,13 +108,13 @@ class ElasticsearchProcessor(IndexAPIProcessor):
         generated_results = 0
         batch_size = 10
         offset = 0
-        body = {
-            'body': query,
-            'index': self.__es_index,
-            'doc_type': self.__card_type,
-            'size': batch_size,
-            'from_': offset,
-        }
+        body = dict(
+            body=query,
+            index=self.__es_index,
+            doc_type=self.__card_type,
+            size=batch_size,
+            from_=offset,
+        )
         if self.__routing:
             body['routing'] = self.__routing
         search_results = self.__es.search(**body)
@@ -129,12 +129,12 @@ class ElasticsearchProcessor(IndexAPIProcessor):
             search_results = self.__es.search(**body)
 
     def __delete_es_docs(self, body, es, index, doc_type):
-        query = {
-            'query': body,
-            'index': index,
-            'doc_type': doc_type,
-            'fields': ['_id']
-        }
+        query = dict(
+            query=body,
+            index=index,
+            doc_type=doc_type,
+            fields=['_id']
+        )
         if self.__routing:
             query['routing'] = self.__routing
         for chunk in chunks(scan(es, **query), 50):

--- a/docido_sdk/index/processor/es_api.py
+++ b/docido_sdk/index/processor/es_api.py
@@ -1,5 +1,7 @@
 from elasticsearch import Elasticsearch as _Elasticsearch
+from elasticsearch.helpers import scan
 
+from docido_sdk.toolbox.collections_ext import chunks
 from docido_sdk.core import (
     Component,
     implements,
@@ -128,13 +130,15 @@ class ElasticsearchProcessor(IndexAPIProcessor):
 
     def __delete_es_docs(self, body, es, index, doc_type):
         query = {
-            'body': body,
+            'query': body,
             'index': index,
             'doc_type': doc_type,
+            'fields': ['_id']
         }
         if self.__routing:
             query['routing'] = self.__routing
-        es.delete_by_query(**query)
+        for chunk in chunks(scan(es, **query), 50):
+            self.delete_cards_by_id(chunk)
 
     def delete_cards(self, query):
         return self.__delete_es_docs(

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     test_suite='docido.sdk.test.suite',
     zip_safe=True,
     install_requires=[
-        'elasticsearch==1.6.0',
+        'elasticsearch==2.3.0',
         'numpy==1.11.0',
         'ProxyTypes==0.9',
         'python-dateutil>=2.5.2',


### PR DESCRIPTION
Replace `delete_by_query` (removed since Elasticsearch 2.0) by
a `scroll | chunk delete`
