### PR TITLE
Fix regression in timestamp_ms parser

### DIFF
--- a/docido_sdk/toolbox/date_ext.py
+++ b/docido_sdk/toolbox/date_ext.py
@@ -30,7 +30,7 @@ class timestamp_ms(object):
     """
 
     TIMEZONE_PARENTHESIS = re.compile('(.*)\(([a-zA-Z]+)[-+0-9:.]*\)$')
-    TIMEZONE_SEPARATOR = re.compile('(.*)(\d\d)[.-](\d\d)$')
+    TIMEZONE_SEPARATOR = re.compile('(.* .*)(\d\d)[.-](\d\d)$')
     QUOTED_TIMEZONE = re.compile("""(.*)['"]([\w:+-]+)['"]?$""")
     START_WITH_DAY_OF_WEEK = re.compile('^([a-zA-Z]*)[\s,](.*)')
 

--- a/tests/test_date_ext.py
+++ b/tests/test_date_ext.py
@@ -218,6 +218,18 @@ class TestDateExt(unittest.TestCase):
         self.assertEqual(timestamp_ms.from_str(format_tz),
                          KIOTO_TIMESTAMP_MS)
 
+    def test_simple_date(self):
+        kioto_date = datetime.datetime(
+            KIOTO_DATETIME.year,
+            KIOTO_DATETIME.month,
+            KIOTO_DATETIME.day
+        )
+        kioto_date_str = '{0.year}-{0.month}-{0.day}'.format(kioto_date)
+        self.assertEqual(
+            timestamp_ms.from_str(kioto_date_str),
+            timestamp_ms.from_datetime(kioto_date)
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Timezone normalizer transformed `2016-01-02` to `2016-01:02` that was then given
to `dateutil.parser.parse(...)`

Fixes #16 
