### PR TITLE
Allow environment variable resolution directly in YAML

### DIFF
--- a/docido_sdk/index/processor/es_api.py
+++ b/docido_sdk/index/processor/es_api.py
@@ -14,8 +14,6 @@ from docido_sdk.index import (
 )
 import docido_sdk.config as docido_config
 
-import os
-
 __all__ = ['Elasticsearch']
 
 ES_BULK_OPERATION = ['index', 'create', 'update', 'delete']
@@ -41,11 +39,11 @@ class ElasticsearchProcessor(IndexAPIProcessor):
         self.__store_type = es_config.ES_STORE_TYPE.format(**fmt)
         self.__routing = config.get('elasticsearch', {}).get('routing')
         self.__es = _Elasticsearch(
-            os.getenv('ELASTICSEARCH_HOST', es_config.ES_HOST),
+            es_config.ES_HOST,
             **es_config.get('connection_params', {})
         )
         self.__es_store = _Elasticsearch(
-            os.getenv('ELASTICSEARCH_HOST', es_config.ES_HOST),
+            es_config.ES_HOST,
             **es_config.get('connection_params', {})
         )
 

--- a/docido_sdk/toolbox/collections_ext.py
+++ b/docido_sdk/toolbox/collections_ext.py
@@ -12,6 +12,10 @@ try:
 except ImportError:  # pragma: no cover
     from yaml import Loader
 
+from . yaml_ext import load_all_yaml_constructors
+
+load_all_yaml_constructors()
+
 
 class nameddict(dict):
     """ Provides dictionary whose keys are accessible via the property

--- a/docido_sdk/toolbox/collections_ext.py
+++ b/docido_sdk/toolbox/collections_ext.py
@@ -5,12 +5,8 @@ import os
 import os.path as osp
 
 from peak.util.proxies import ObjectWrapper
-
 import yaml
-try:
-    from yaml import CLoader as Loader
-except ImportError:  # pragma: no cover
-    from yaml import Loader
+from yaml import Loader
 
 from . yaml_ext import load_all_yaml_constructors
 

--- a/docido_sdk/toolbox/yaml_ext.py
+++ b/docido_sdk/toolbox/yaml_ext.py
@@ -1,0 +1,31 @@
+"""
+Provides utilities related to PyYaml
+"""
+import os
+
+
+def envvar_constructor(loader, node):
+    """Tag constructor to use environment variables in YAML files. Usage:
+
+    - !TAG VARIABLE
+        raise while loading the document if variable does not exists
+    - !TAG VARIABLE:=DEFAULT_VALUE
+
+    For instance:
+
+        credentials:
+            user: !env USER:=root
+            group: !env GROUP:= root
+    """
+    value = loader.construct_python_unicode(node)
+    data = value.split(':=', 1)
+    if len(data) == 2:
+        var, default = data
+        return os.environ.get(var, default)
+    else:
+        return os.environ[value]
+
+
+def load_all_yaml_constructors():
+    import yaml
+    yaml.add_constructor(u'!env', envvar_constructor)

--- a/tests/test_es_api.yml
+++ b/tests/test_es_api.yml
@@ -1,4 +1,4 @@
-elasticsearch: &elasticsearch local.docker:9200
+elasticsearch: &elasticsearch !env ELASTICSEARCH_HOST:=localhost:9200
 
 elasticsearch:
     ES_CARD_TYPE: item

--- a/tests/test_oauth_token.py
+++ b/tests/test_oauth_token.py
@@ -1,0 +1,23 @@
+import unittest
+
+from docido_sdk.oauth import OAuthToken
+
+
+class TestOAuthToken(unittest.TestCase):
+    def test_create_oauth_token(self):
+        token = OAuthToken(
+            access_token=1,
+            refresh_token=2,
+            token_secret=3,
+            consumer_key=4,
+            expires=5
+        )
+        self.assertEqual(1, token.access_token)
+        self.assertEqual(2, token.refresh_token)
+        self.assertEqual(3, token.token_secret)
+        self.assertEqual(4, token.consumer_key)
+        self.assertEqual(5, token.expires)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_yaml_ext.py
+++ b/tests/test_yaml_ext.py
@@ -1,0 +1,60 @@
+import os
+from StringIO import StringIO
+import unittest
+
+
+import yaml
+try:
+    from yaml import CLoader as Loader
+except ImportError:  # pragma: no cover
+    from yaml import Loader
+
+from docido_sdk.toolbox.yaml_ext import load_all_yaml_constructors
+
+load_all_yaml_constructors()
+
+
+class TestYamlExt(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.environ['DOCIDO_SDK_YAML_EXT_UT'] = '42'
+        os.environ.pop('DOCIDO_SDK_YAML_MISSING', None)
+
+    @classmethod
+    def tearDownClass(cls):
+        os.environ.pop('DOCIDO_SDK_YAML_EXT_UT')
+
+    def test_missing_mandatory_env(self):
+        with self.assertRaises(KeyError) as exc:
+            self._get_var_env('DOCIDO_SDK_YAML_MISSING')
+        self.assertEqual(
+            (u'DOCIDO_SDK_YAML_MISSING',),
+            exc.exception.args
+        )
+
+    def test_get_mandatory_env(self):
+        self.assertEqual(
+            '42',
+            self._get_var_env('DOCIDO_SDK_YAML_EXT_UT')
+        )
+
+    def test_get_var_with_default_value(self):
+        self.assertEqual(
+            '42',
+            self._get_var_env('DOCIDO_SDK_YAML_EXT_UT:=43')
+        )
+
+    def test_get_default_value(self):
+        self.assertEqual(
+            '44',
+            self._get_var_env('DOCIDO_SDK_YAML_MISSING:=44')
+        )
+
+    def _get_var_env(self, expr):
+        yaml_str = 'foo: !env ' + expr
+        config = yaml.load(StringIO(yaml_str), Loader=Loader)
+        return config['foo']
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_yaml_ext.py
+++ b/tests/test_yaml_ext.py
@@ -2,16 +2,7 @@ import os
 from StringIO import StringIO
 import unittest
 
-
-import yaml
-try:
-    from yaml import CLoader as Loader
-except ImportError:  # pragma: no cover
-    from yaml import Loader
-
-from docido_sdk.toolbox.yaml_ext import load_all_yaml_constructors
-
-load_all_yaml_constructors()
+from docido_sdk.toolbox.collections_ext import yaml, Loader
 
 
 class TestYamlExt(unittest.TestCase):


### PR DESCRIPTION
This does not seem one, but this is major step forward that will allow us to test our code with different containers in parallel.
